### PR TITLE
add methods for querying the verison and path of libfuse

### DIFF
--- a/src/refuse/high.py
+++ b/src/refuse/high.py
@@ -726,6 +726,29 @@ def fuse_exit():
     _libfuse.fuse_exit(fuse_ptr)
 
 
+def get_fuse_version():
+    for method in [
+        lambda: _libfuse.fuse_pkgversion(),
+        lambda: _libfuse.fuse3_pkgversion(),
+        lambda: _libfuse.fuse_version(),
+        lambda: _libfuse.fuse3_version(),
+        lambda: _libfuse.macfuse_version(),
+        lambda: _libfuse.osxfuse_version(),
+    ]:
+        try:
+            val = method()
+            if isinstance(val, int) and val > 10:
+                return str(val / 10)
+            else:
+                return val
+        except AttributeError:
+            pass
+
+
+def get_fuse_libfile():
+    return _libfuse._name
+
+
 class FuseOSError(OSError):
     def __init__(self, errno):
         super(FuseOSError, self).__init__(errno, os.strerror(errno))


### PR DESCRIPTION
Might be interesting for debugging to get more information about the current environment.
I didn't test every OS, but the given function names should cover pretty much everything.

Note: maybe this generic functionality (together with `fuse_exit`) should be in a file that can be shared between low- and high-level API
