### PR TITLE
fix self.__critical_exception use in staticmethod FUSE._wrapper

### DIFF
--- a/src/refuse/high.py
+++ b/src/refuse/high.py
@@ -849,8 +849,7 @@ class FUSE:
             else:
                 yield '%s=%s' % (key, value)
 
-    @staticmethod
-    def _wrapper(func, *args, **kwargs):
+    def _wrapper(self, func, *args, **kwargs):
         'Decorator for the methods that follow'
 
         try:


### PR DESCRIPTION
fixes #26 and also the second exception in https://github.com/N-Coder/studip-fuse/issues/21

@s-m-e is a 0.0.4 release to pypi somewhere near in sight? The `develop` branch contains some [refactorings](https://github.com/pleiszenburg/refuse/compare/master...pleiszenburg:develop) and also some bugfixes, but no news since last year. As all this is alpha quality software and we agreed that users should exactly fix the version they want to use, this shouldn't hurt.