### PR TITLE
Fix missing sys import causing error on Windows

### DIFF
--- a/src/refuse/_refactor.py
+++ b/src/refuse/_refactor.py
@@ -34,6 +34,7 @@ specific language governing rights and limitations under the License.
 import os
 import ctypes
 from ctypes.util import find_library
+import sys
 
 
 # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
This line in a Windows block of _refactor.py references `sys`, but `sys` hasn't been imported:

https://github.com/pleiszenburg/refuse/blob/38a960dc188fbf9847062774329ca5ee6abc2f44/src/refuse/_refactor.py#L71

Confirmed on my machine this allow `refuse` to find WinFSP.